### PR TITLE
Replace deprecated `cp -n` by `cp --update=none`

### DIFF
--- a/code_setup.sh
+++ b/code_setup.sh
@@ -208,7 +208,7 @@ function deployFile() {
 	mkdir -p ${DEST_DIR};
 	checkResult $?;
 	echo "> Deploying '$SRC_FILE_PATH'...";
-	cp --update=none -p $SRC_FILE_PATH $DEST_FILE_PATH;
+	cp --update=none -p "$SRC_FILE_PATH" "$DEST_FILE_PATH";
 	local RESULT=$?;
 	if [[ ${RESULT} -ne 0 ]]; then
 		echo "> Error while deploying file '$SRC_FILE_PATH'!";

--- a/code_setup.sh
+++ b/code_setup.sh
@@ -208,7 +208,7 @@ function deployFile() {
 	mkdir -p ${DEST_DIR};
 	checkResult $?;
 	echo "> Deploying '$SRC_FILE_PATH'...";
-	cp -n -p $SRC_FILE_PATH $DEST_FILE_PATH;
+	cp --update=none -p $SRC_FILE_PATH $DEST_FILE_PATH;
 	local RESULT=$?;
 	if [[ ${RESULT} -ne 0 ]]; then
 		echo "> Error while deploying file '$SRC_FILE_PATH'!";

--- a/sync.sh
+++ b/sync.sh
@@ -201,12 +201,12 @@ function deployFile() {
 		checkResult $?;
 	fi
 	echo -n ">>> Deploying '$SRC_FILE_PATH' to '${DEST_FILE_PATH}'...";
-	# cp -n -p does NOT work on OS X => rm 1st
+	# cp --update=none -p does NOT work on OS X => rm 1st
 	if [[ -f "${DEST_FILE_PATH}" ]]; then
 		rm ${DEST_FILE_PATH};
 		checkResult $?;
 	fi
-	cp -n -p "${SRC_FILE_PATH}" "${DEST_FILE_PATH}";
+	cp --update=none -p "${SRC_FILE_PATH}" "${DEST_FILE_PATH}";
 	local RESULT=$?;
 	if [[ ${RESULT} -ne 0 ]]; then
 		echo " ERROR!";


### PR DESCRIPTION
> cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead

> UPDATE controls which existing files in the destination are replaced.  
'all' is the default operation when an --update option is not specified, and results in all existing files in the destination being replaced.  
**'none' is like the --no-clobber option, in that no files in the destination are replaced, and skipped files do not induce a failure.** 
'none-fail' also ensures no files are replaced in the destination, but any skipped files are diagnosed and induce a failure. 'older' is the default operation when --update is specified, and results in files being replaced if they're older than the corresponding source file.

https://man7.org/linux/man-pages/man1/cp.1.html