### PR TITLE
Generated images > make Inkscape optional (use `MT_GENERATE_IMAGES=true` to force)

### DIFF
--- a/shared-modules/app-android/src/main/play/listings/en-US/graphics/feature-graphic/MT1.png.MT.sh
+++ b/shared-modules/app-android/src/main/play/listings/en-US/graphics/feature-graphic/MT1.png.MT.sh
@@ -23,8 +23,12 @@ FILE_1_PNG="${FEATURE_GRAPHIC_DIR}/1.png";
 mkdir -p "${FEATURE_GRAPHIC_DIR}";
 checkResult $?;
 if [ -f "${FILE_1_PNG}" ]; then
-  echo ">> File '$FILE_1_PNG' already exist."; # compat with existing feature-graphic/1.png
-  exit 0;
+  if [[ ${MT_GENERATE_IMAGES} != true ]]; then
+    echo ">> File '$FILE_1_PNG' already exist."; # compat with existing feature-graphic/1.png
+    exit 0;
+  else
+    echo ">> File '$FILE_1_PNG' already exist: overriding image... (MT_GENERATE_IMAGES=$MT_GENERATE_IMAGES)";
+  fi
 fi
 
 rm -f "${FILE_1_PNG}";
@@ -103,6 +107,7 @@ fi
 MAX_CITY_LENGTH=77 # from module-featured-graphic.sh
 CITIES_LABEL=$(echo $CITIES_LABEL | awk -v len=$MAX_CITY_LENGTH '{ if (length($0) > len) print substr($0, 1, len-1) "…"; else print; }');
 
+# uses inkscape
 if [[ -z "${AGENCY_NAME_2}" ]]; then
   $ROOT_DIR/commons-android/pub/module-featured-graphic.sh "$AGENCY_NAME_1" "$CITIES_LABEL" "$STATE_AND_COUNTRY_LABEL";
   checkResult $?;

--- a/shared-modules/app-android/src/main/play/listings/en-US/graphics/icon/MT1.png.MT.sh
+++ b/shared-modules/app-android/src/main/play/listings/en-US/graphics/icon/MT1.png.MT.sh
@@ -23,14 +23,18 @@ FILE_1_PNG="${FEATURE_GRAPHIC_DIR}/1.png";
 mkdir -p "${FEATURE_GRAPHIC_DIR}";
 checkResult $?;
 if [ -f "${FILE_1_PNG}" ]; then
-  echo ">> File '$FILE_1_PNG' already exist."; # compat with existing icon/1.png
-  exit 0;
+  if [[ ${MT_GENERATE_IMAGES} != true ]]; then
+    echo ">> File '$FILE_1_PNG' already exist."; # compat with existing icon/1.png
+    exit 0;
+  else
+    echo ">> File '$FILE_1_PNG' already exist: overriding image... (MT_GENERATE_IMAGES=$MT_GENERATE_IMAGES)";
+  fi
 fi
 
 rm -f "${FILE_1_PNG}";
 checkResult $?;
 
-$ROOT_DIR/commons-android/pub/module-hi-res-app-icon.sh;
+$ROOT_DIR/commons-android/pub/module-hi-res-app-icon.sh; # uses inkscape
 checkResult $?;
 
 echo ">> Generating icon/1.png... DONE";

--- a/shared-modules/app-android/src/main/res/MTmipmap-MTSTAR/MTmodule_app_icon.png.MT.sh
+++ b/shared-modules/app-android/src/main/res/MTmipmap-MTSTAR/MTmodule_app_icon.png.MT.sh
@@ -15,7 +15,6 @@ APP_ANDROID_DIR="${ROOT_DIR}/app-android";
 SRC_DIR="${APP_ANDROID_DIR}/src";
 MAIN_DIR="${SRC_DIR}/main";
 RES_DIR="${MAIN_DIR}/res";
-echo "RES_DIR: $RES_DIR";
 
 REQUIRED_ICON_FILE="${MAIN_DIR}/play/listings/en-US/graphics/icon/1.png";
 if [ ! -f "$REQUIRED_ICON_FILE" ]; then

--- a/shared-overwrite/.circleci/config.yml
+++ b/shared-overwrite/.circleci/config.yml
@@ -44,11 +44,10 @@ jobs:
       TZ: "America/Toronto"
     steps:
       - run:
-          name: APT install - gawk & inkscape & libxml2-utils
+          name: APT install - gawk & libxml2-utils
           command: |
             sudo apt-get update
             sudo apt-get install -y gawk
-            sudo apt-get install -y inkscape
             sudo apt-get install -y libxml2-utils
       - android/change_java_version:
           java_version: 17

--- a/shared/app-android/MT.gitignore
+++ b/shared/app-android/MT.gitignore
@@ -62,12 +62,11 @@ proguard/
 /src/main/play/listings/en-US/title.txt
 /src/main/play/listings/en-US/short-description.txt
 /src/main/play/listings/en-US/full-description.txt
-/src/main/play/listings/en-US/graphics/feature-graphic/1.png
-# /src/main/play/listings/en-US/graphics/icon/1.png # used in README.md
+# /src/main/play/listings/en-US/graphics/feature-graphic/1.png # generated image optional
+# /src/main/play/listings/en-US/graphics/icon/1.png # used in README.md # generated image optional
 /src/main/play/listings/fr-FR/title.txt
 /src/main/play/listings/fr-FR/short-description.txt
 /src/main/play/listings/fr-FR/full-description.txt
-/src/main/play/listings/fr-FR/graphics/feature-graphic/1.png
 /src/main/res/mipmap-*/module_app_icon.png
 /src/main/res/values/bike_station_strings.xml
 /src/main/res/values/strings.xml


### PR DESCRIPTION
This is backward compatible: if file is missing, Inkscape will be installed and used.