### PR TITLE
Turn ON minify for modules #R8 #Proguard

### DIFF
--- a/shared/app-android/build.gradle
+++ b/shared/app-android/build.gradle
@@ -231,9 +231,6 @@ android {
             // testCoverageEnabled false // DEBUG skip coverage report
             shrinkResources = false
             if (isMainApp) {
-                minifyEnabled = false
-                proguardFiles getDefaultProguardFile("proguard-android.txt"),
-                        "proguard-rules.pro"
                 multiDexEnabled = true
                 firebaseCrashlytics {
                     // https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=android#keep_obfuscated_build_variants
@@ -243,8 +240,6 @@ android {
                     // https://firebase.google.com/docs/perf-mon/disable-sdk?platform=android#disable-gradle-plugin
                     instrumentationEnabled = false
                 }
-            } else {
-                minifyEnabled = false
             }
             aaptOptions.cruncherEnabled = false
         }
@@ -266,8 +261,10 @@ android {
                 proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), // "proguard-android.txt"),
                         "proguard-rules.pro"
             } else {
-                shrinkResources = false
-                minifyEnabled = false
+                shrinkResources = true
+                minifyEnabled = true
+                // https://android.googlesource.com/platform/sdk/+/master/files/proguard-android-optimize.txt
+                proguardFiles getDefaultProguardFile("proguard-android-optimize.txt") // no code in module "app-android" -> no "proguard-rules.pro"
             }
         }
     }


### PR DESCRIPTION
This saves `4 MB` of unused code/dependencies.

-----
Tests:
- [x] Twitter/YouTube news provider using GSON
- [x] current/next stops schedule dynamic file names `R.raw.[abc]_gtfs_schedule_stop_[12345]`