### PR TITLE
Add timeout to MT Release job in workflow

### DIFF
--- a/shared-overwrite/.github/workflows/mt-release.yml
+++ b/shared-overwrite/.github/workflows/mt-release.yml
@@ -78,6 +78,7 @@ jobs:
   MT-RELEASE-JOB:
     if: ${{ github.ref_name == github.event.repository.default_branch || github.event.inputs.allowNonDefault == 'true' }}
     name: "MT Release"
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: MT check out main repository code (with submodules)


### PR DESCRIPTION
Workflow can be stuck for 40+ minutes in `actions/checkout`...
- https://github.com/mtransitapps/ca-quebec-rtc-bus-android/actions/runs/23194489418