### PR TITLE
Circle CI: only build `master` branch

### DIFF
--- a/shared-overwrite/.circleci/config.yml
+++ b/shared-overwrite/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
             branches:
                 only:
                     - master
-                    - /^mm\/.*/ # starts with "mm/"
+                    # - /^mm\/.*/ # starts with "mm/"
                     # - TODO other branch?
 jobs:
   mt-job:


### PR DESCRIPTION
Comment out the filter for branches starting with 'mm/' in CircleCI config.