### PR TITLE
Target SDK `36` (Android 16) before Aug 31, 2026

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@
 sdk-min = "24"
 # Android 17 Cinnamon Bun (update 1st)
 sdk-compile = "37"
-# Android 15 Vanilla Ice Cream (update 2nd)
-sdk-target = "35"
+# Android 16 Baklava (update 2nd)
+sdk-target = "36"
 # https://developer.android.com/tools/releases/build-tools
 # Android 17 Cinnamon Bun
 buildTools = "37.0.0"


### PR DESCRIPTION
- https://github.com/mtransitapps/mtransit-for-android/pull/379

Tasks:
- [x] bump target SDK to `36` 

Links:
- [Target API level requirements for Google Play apps](https://support.google.com/googleplay/android-developer/answer/11926878)
- https://developer.android.com/about/versions/16/behavior-changes-16