### PR TITLE
Use `git update-index --skip-worktree` to hide locally changed "key" files

### DIFF
--- a/shared/app-android/keys_cleanup.sh
+++ b/shared/app-android/keys_cleanup.sh
@@ -47,7 +47,7 @@ for FILE in "${FILES[@]}" ; do
 			exit ${RESULT};
 		fi
 	else # file is tracked by git
-	  git update-index --no-skip-worktree ${FILE_PATH};
+		git update-index --no-skip-worktree -- "${FILE_PATH}";
 		RESULT=$?;
 		if [[ ${RESULT} -ne 0 ]]; then
 			echo " ERROR! while setting '--no-skip-worktree' for '${FILE_PATH}'!";

--- a/shared/app-android/keys_cleanup.sh
+++ b/shared/app-android/keys_cleanup.sh
@@ -47,10 +47,10 @@ for FILE in "${FILES[@]}" ; do
 			exit ${RESULT};
 		fi
 	else # file is tracked by git
-	    git update-index --no-skip-worktree ${FILE_PATH};
+	  git update-index --no-skip-worktree ${FILE_PATH};
 		RESULT=$?;
 		if [[ ${RESULT} -ne 0 ]]; then
-			echo " ERROR! while unsetting 'skip-worktree' for '${FILE_PATH}'!";
+			echo " ERROR! while setting '--no-skip-worktree' for '${FILE_PATH}'!";
 			exit ${RESULT};
 		fi
 		git checkout -- ${FILE_PATH};

--- a/shared/app-android/keys_cleanup.sh
+++ b/shared/app-android/keys_cleanup.sh
@@ -47,6 +47,12 @@ for FILE in "${FILES[@]}" ; do
 			exit ${RESULT};
 		fi
 	else # file is tracked by git
+	    git update-index --no-skip-worktree ${FILE_PATH};
+		RESULT=$?;
+		if [[ ${RESULT} -ne 0 ]]; then
+			echo " ERROR! while unsetting 'skip-worktree' for '${FILE_PATH}'!";
+			exit ${RESULT};
+		fi
 		git checkout -- ${FILE_PATH};
 		RESULT=$?;
 		if [[ ${RESULT} -ne 0 ]]; then

--- a/shared/app-android/keys_setup.sh
+++ b/shared/app-android/keys_setup.sh
@@ -113,6 +113,12 @@ for FILE in "${FILES[@]}" ; do
 			ls -al ${FILE_ENC}; #DEBUG
 			exit 1;
 		fi
+		git update-index --skip-worktree ${FILE_PATH};
+		RESULT=$?;
+		if [[ ${RESULT} -ne 0 ]]; then
+			echo " ERROR! while setting 'skip-worktree' for '${FILE_PATH}'!";
+			exit ${RESULT};
+		fi
 	fi
 
 	echoFile " DONE ✓";

--- a/shared/app-android/keys_setup.sh
+++ b/shared/app-android/keys_setup.sh
@@ -113,7 +113,7 @@ for FILE in "${FILES[@]}" ; do
 			ls -al ${FILE_ENC}; #DEBUG
 			exit 1;
 		fi
-		git update-index --skip-worktree ${FILE_PATH};
+		git update-index --skip-worktree -- "${FILE_PATH}";
 		RESULT=$?;
 		if [[ ${RESULT} -ne 0 ]]; then
 			echo " ERROR! while setting 'skip-worktree' for '${FILE_PATH}'!";


### PR DESCRIPTION
- #818