### PR TITLE
Bump org.xerial:sqlite-jdbc from 3.53.0.0 to 3.53.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -152,7 +152,7 @@ commons-io = "2.22.0"
 commons-lang3 = "3.20.0"
 commons-text = "1.15.0"
 # https://github.com/xerial/sqlite-jdbc/releases/latest
-xerial-SQLiteJDBC = "3.53.0.0"
+xerial-SQLiteJDBC = "3.53.2.0"
 
 [libraries]
 kotlin-bom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlin" }

--- a/shared-opt-dir/parser/dependencies/compileClasspath.txt
+++ b/shared-opt-dir/parser/dependencies/compileClasspath.txt
@@ -21,4 +21,4 @@ org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0
 org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0
 org.jetbrains:annotations:23.0.0
 org.jspecify:jspecify:1.0.0
-org.xerial:sqlite-jdbc:3.53.0.0
+org.xerial:sqlite-jdbc:3.53.2.0

--- a/shared-opt-dir/parser/dependencies/runtimeClasspath.txt
+++ b/shared-opt-dir/parser/dependencies/runtimeClasspath.txt
@@ -21,4 +21,4 @@ org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0
 org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0
 org.jetbrains:annotations:23.0.0
 org.jspecify:jspecify:1.0.0
-org.xerial:sqlite-jdbc:3.53.0.0
+org.xerial:sqlite-jdbc:3.53.2.0

--- a/shared-opt-dir/parser/dependencies/testCompileClasspath.txt
+++ b/shared-opt-dir/parser/dependencies/testCompileClasspath.txt
@@ -31,4 +31,4 @@ org.jetbrains:annotations:23.0.0
 org.jspecify:jspecify:1.0.0
 org.mockito.kotlin:mockito-kotlin:6.3.0
 org.mockito:mockito-core:5.23.0
-org.xerial:sqlite-jdbc:3.53.0.0
+org.xerial:sqlite-jdbc:3.53.2.0

--- a/shared-opt-dir/parser/dependencies/testRuntimeClasspath.txt
+++ b/shared-opt-dir/parser/dependencies/testRuntimeClasspath.txt
@@ -33,4 +33,4 @@ org.jspecify:jspecify:1.0.0
 org.mockito.kotlin:mockito-kotlin:6.3.0
 org.mockito:mockito-core:5.23.0
 org.objenesis:objenesis:3.3
-org.xerial:sqlite-jdbc:3.53.0.0
+org.xerial:sqlite-jdbc:3.53.2.0


### PR DESCRIPTION
- https://github.com/xerial/sqlite-jdbc/compare/3.53.0.0...3.53.2.0