### PR TITLE
Update Liftoff/Vungle from 7.7.4.2 to 7.7.6.0.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,7 +107,7 @@ fbAudienceNetwork-mediation = "6.21.0.4"
 appLovin-mediation = "13.6.3.0"
 # Liftoff = Vungle
 #vungle = "_._._" # included with nediation adapter
-vungle-mediation = "7.7.4.2"
+vungle-mediation = "7.7.6.0"
 # https://github.com/google/guava/releases/latest
 guava = "33.6.0-android"
 # https://github.com/square/leakcanary/releases

--- a/shared-main/app-android/dependencies/releaseCompileClasspath.txt
+++ b/shared-main/app-android/dependencies/releaseCompileClasspath.txt
@@ -106,7 +106,7 @@ com.github.chuckerteam.chucker:library-no-op:4.3.1
 com.google.ads.mediation:applovin:13.6.3.0
 com.google.ads.mediation:common:1.1.0
 com.google.ads.mediation:facebook:6.21.0.4
-com.google.ads.mediation:vungle:7.7.4.2
+com.google.ads.mediation:vungle:7.7.6.0
 com.google.android.datatransport:transport-api:3.1.0
 com.google.android.datatransport:transport-backend-cct:3.2.0
 com.google.android.datatransport:transport-runtime:3.2.0
@@ -181,7 +181,7 @@ com.squareup.okio:okio-jvm:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.retrofit2:converter-gson:3.0.0
 com.squareup.retrofit2:retrofit:3.0.0
-com.vungle:vungle-ads:7.7.4
+com.vungle:vungle-ads:7.7.6
 jakarta.inject:jakarta.inject-api:2.0.1
 javax.inject:javax.inject:1
 org.checkerframework:checker-qual:3.43.0

--- a/shared-main/app-android/dependencies/releaseRuntimeClasspath.txt
+++ b/shared-main/app-android/dependencies/releaseRuntimeClasspath.txt
@@ -128,7 +128,7 @@ com.github.chuckerteam.chucker:library-no-op:4.3.1
 com.google.ads.mediation:applovin:13.6.3.0
 com.google.ads.mediation:common:1.1.0
 com.google.ads.mediation:facebook:6.21.0.4
-com.google.ads.mediation:vungle:7.7.4.2
+com.google.ads.mediation:vungle:7.7.6.0
 com.google.android.datatransport:transport-api:3.2.0
 com.google.android.datatransport:transport-backend-cct:3.3.0
 com.google.android.datatransport:transport-runtime:3.3.0
@@ -208,7 +208,7 @@ com.squareup.okio:okio-jvm:3.17.0
 com.squareup.okio:okio:3.17.0
 com.squareup.retrofit2:converter-gson:3.0.0
 com.squareup.retrofit2:retrofit:3.0.0
-com.vungle:vungle-ads:7.7.4
+com.vungle:vungle-ads:7.7.6
 io.github.pdvrieze.xmlutil:core-jvmcommon:0.91.3
 io.github.pdvrieze.xmlutil:core:0.91.3
 io.github.pdvrieze.xmlutil:serialization-jvm:0.91.3


### PR DESCRIPTION
- https://github.com/Vungle/VungleAds-SDK/blob/master/CHANGELOG-Android.md#vungle-sdk-for-androidamazon-776-july-13-2026
- https://github.com/googleads/googleads-mobile-android-mediation/blob/main/ThirdPartyAdapters/liftoffmonetize/CHANGELOG.md#version-7760