### PR TITLE
`mt-download.yml` > omit `--ref` on default branch to avoid `mt-sync-code-data.yml` starting with the wrong hash

### DIFF
--- a/shared-overwrite/.github/workflows/mt-download-data.yml
+++ b/shared-overwrite/.github/workflows/mt-download-data.yml
@@ -96,7 +96,12 @@ jobs:
             echo ">> No new data downloaded and data is up-to-date. No sync needed.";
           else
             echo ">> New data downloaded or data is outdated. Triggering mt-sync-code-data.yml workflow (skip download data)...";
-            gh workflow run mt-sync-code-data.yml --ref "$MT_BRANCH_NAME" -f skip-download-data=true
+            if [[ "$MT_BRANCH_NAME" == "$MT_DEFAULT_BRANCH_NAME" ]]; then
+              echo ">> Dispatching on default branch without --ref.";
+              gh workflow run mt-sync-code-data.yml -f skip-download-data=true
+            else
+              gh workflow run mt-sync-code-data.yml --ref "$MT_BRANCH_NAME" -f skip-download-data=true
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.MT_PAT }}


### PR DESCRIPTION
Sometimes `mt-sync-code-data.yml` was starting with an old git hash on the branch, not taking into account the just pushed commit in previous workflow step.

Example:
- `mt-download.yml` > 🟢  https://github.com/mtransitapps/fr-haute-garonne-lio-bus-android/actions/runs/30631406940/job/91158383088
- `mt-sync-code-data.yml` > 🔴  https://github.com/mtransitapps/fr-haute-garonne-lio-bus-android/actions/runs/30631617620/job/91178005250